### PR TITLE
Support for Torrent file upload

### DIFF
--- a/src/main/scala/com/pinkstack/ta2/Aria2Client.scala
+++ b/src/main/scala/com/pinkstack/ta2/Aria2Client.scala
@@ -22,6 +22,8 @@ trait Aria2Client {
   def tellStatus(gid: GID): IO[Download]
 
   def addUri(uri: String): IO[GID]
+  def addTorrent(file: String): IO[GID]
+
   def remove(gid: GID): IO[GID]
   def removeDownloadResult(gid: GID): IO[GID]
 
@@ -83,6 +85,9 @@ final class Aria2ClientImpl private (
 
   override def addUri(uri: GID): IO[GID] =
     defineRPC[GID]("aria2.addUri", Json.arr(Json.fromString(uri)))
+
+  override def addTorrent(file: GID): IO[GID] =
+    defineRPC[GID]("aria2.addTorrent", Json.fromString(file))
 
   override def remove(gid: GID): IO[GID] =
     defineRPC[GID]("aria2.remove", Json.fromString(gid))

--- a/src/main/scala/com/pinkstack/ta2/Aria2Client.scala
+++ b/src/main/scala/com/pinkstack/ta2/Aria2Client.scala
@@ -100,7 +100,8 @@ object Aria2Client:
     for
       client      <- BlazeClientBuilder[IO].withoutSslContext
         .withConnectTimeout(3.seconds)
-        .withRequestTimeout(4.seconds)
+        .withRequestTimeout(3.seconds)
+        .withRetries(2)
         .resource
       aria2client <- Resource.pure(Aria2ClientImpl.make(config, client))
     yield aria2client

--- a/src/main/scala/com/pinkstack/ta2/MultipartProcessor.scala
+++ b/src/main/scala/com/pinkstack/ta2/MultipartProcessor.scala
@@ -1,0 +1,54 @@
+package com.pinkstack.ta2
+
+import cats.data.{NonEmptyList, OptionT}
+import cats.implicits.*
+import cats.effect.IO
+import org.http4s.*
+import org.http4s.dsl.*
+import org.http4s.dsl.io.*
+import org.http4s.implicits.*
+import org.http4s.headers.*
+import org.http4s.multipart.{Multipart, Part}
+import org.http4s.MediaType.*
+import org.typelevel.ci.CIString
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+import scodec.bits.ByteVector
+
+import scala.jdk.CollectionConverters.*
+import java.util.Base64
+
+enum MultipartProcessorResult:
+  case Base64EncodedFile(file: String)
+  case InvalidFileKind(kind: String)
+  case EmptyForm()
+
+object MultipartProcessor {
+  import MultipartProcessorResult.*
+  given loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
+  private val logger                     = loggerFactory.getLogger
+
+  private def parseAsTorrent(part: Part[IO]): IO[Base64EncodedFile] = for {
+    bodyAsVector <- part.body.compile.toVector.map(ByteVector(_))
+    bodyAsBase64 <- IO(Base64.getEncoder.encode(bodyAsVector.toArray))
+  } yield Base64EncodedFile(new String(bodyAsBase64))
+
+  private def parseAsEmptyForm(part: Part[IO]): IO[EmptyForm] =
+    IO.println("empty form") *> IO.pure(EmptyForm())
+
+  def process(multipart: Multipart[IO]): IO[MultipartProcessorResult] =
+    val pom: IO[Vector[Option[MultipartProcessorResult]]] = multipart.parts.map { part =>
+      part.headers.get(CIString.apply("Content-Type")) match {
+        case Some(NonEmptyList(Header.Raw(_, "application/x-bittorrent"), _)) => parseAsTorrent(part).map(Some(_))
+        case Some(NonEmptyList(Header.Raw(_, "application/octet-stream"), _)) => parseAsEmptyForm(part).map(Some(_))
+        case Some(NonEmptyList(Header.Raw(_, kind), _))                       =>
+          logger.warn(s"Unsupported header kind - $kind") *> IO.pure(InvalidFileKind(kind).some)
+        case None                                                             => IO.pure(None)
+      }
+    }.sequence
+
+    pom.flatMap { v =>
+      IO.fromOption(v.collectFirst { case Some(v) => v })(new RuntimeException("Failed parsing payload."))
+    }
+
+}

--- a/src/main/scala/com/pinkstack/ta2/NewDownload.scala
+++ b/src/main/scala/com/pinkstack/ta2/NewDownload.scala
@@ -2,10 +2,14 @@ package com.pinkstack.ta2
 
 import cats.syntax.all.*
 import org.http4s.FormDataDecoder
+import org.http4s.FormDataDecoder._
+import org.http4s.multipart._
+
+import java.io.File
 
 final case class NewDownload(
   uri: String,
-  hidden: Boolean
+  hidden: Boolean = false
 )
 
 object NewDownloadDecoder {
@@ -14,6 +18,7 @@ object NewDownloadDecoder {
   given FormDataDecoder[NewDownload] =
     (
       field[String]("uri"),
+      // field[File]("file"),
       field[Boolean]("hidden")
-    ).mapN { case (a, b) => NewDownload(a, b) }
+    ).mapN { case (uri, file) => NewDownload(uri, file) }
 }

--- a/src/main/scala/com/pinkstack/ta2/NewDownload.scala
+++ b/src/main/scala/com/pinkstack/ta2/NewDownload.scala
@@ -1,11 +1,11 @@
 package com.pinkstack.ta2
 
 import cats.syntax.all.*
-import org.http4s.FormDataDecoder
-import org.http4s.FormDataDecoder._
-import org.http4s.multipart._
+import org.http4s.{EntityEncoder, FormDataDecoder}
+import org.http4s.FormDataDecoder.*
+import org.http4s.multipart.*
 
-import java.io.File
+import java.io.{File, InputStream}
 
 final case class NewDownload(
   uri: String,
@@ -14,6 +14,27 @@ final case class NewDownload(
 
 object NewDownloadDecoder {
   import org.http4s.FormDataDecoder.*
+
+  /*
+  implicit def inputStreamEncoder[A <: InputStream]: EntityEncoder[Eval[A]] =
+    sourceEncoder[Byte].contramap { in: Eval[A] =>
+      readInputStream[Task](Task.delay(in.value), DefaultChunkSize)
+    }
+
+  implicit def sourceEncoder[A](implicit W: EntityEncoder[A]): EntityEncoder[Stream[Task, A]] =
+    new EntityEncoder[Stream[Task, A]] {
+      override def toEntity(a: Stream[Task, A]): Task[Entity] =
+        Task.now(Entity(a.evalMap(W.toEntity).flatMap(_.body)))
+
+      override def headers: Headers =
+        W.headers.get(`Transfer-Encoding`) match {
+          case Some(transferCoding) if transferCoding.hasChunked =>
+            W.headers
+          case _ =>
+            W.headers.put(`Transfer-Encoding`(TransferCoding.chunked))
+        }
+    }
+  */
 
   given FormDataDecoder[NewDownload] =
     (

--- a/src/main/scala/com/pinkstack/ta2/WebService.scala
+++ b/src/main/scala/com/pinkstack/ta2/WebService.scala
@@ -19,6 +19,7 @@ import org.http4s.Charset.`UTF-8`
 import scalatags.Text
 import cats.data.Validated.*
 import cats.syntax.all.*
+import org.http4s.multipart.*
 
 final case class WebService private (config: Config, client: Aria2Client) {
   import NewDownloadDecoder.given
@@ -111,6 +112,29 @@ final case class WebService private (config: Config, client: Aria2Client) {
         yield response
 
       case req @ POST -> Root / "new-download" =>
+        for
+          multipart        <- req.as[Multipart[IO]]
+          _ <- {
+            def fileParts = multipart.parts.collectFirst {
+              case part /* if */ => part
+            }
+            
+            
+            
+            fileParts
+          }
+          response <- Ok("all good")
+        yield response
+
+      /*
+        req.as[Multipart[IO]] { case parts: Multipart[IO] =>
+          def fileParts = parts.parts.filter(_.filename.isDefined)
+
+          // for file <- fileParts
+          // do IO.println("Hello.")
+          Ok("got it.")
+        }*/
+      /*
         req
           .as[NewDownload]
           .flatMap { newDownload =>
@@ -119,7 +143,7 @@ final case class WebService private (config: Config, client: Aria2Client) {
               .flatMap(gid => renderInfo(s"Added new download. GID: $gid"))
           }
           .handleErrorWith(renderError)
-          .flatMap(Ok(_))
+          .flatMap(Ok(_)) */
     }
 
   val httpApp: Kleisli[IO, Request[IO], Response[IO]] = routes.orNotFound

--- a/src/main/scala/com/pinkstack/ta2/layout/Layout.scala
+++ b/src/main/scala/com/pinkstack/ta2/layout/Layout.scala
@@ -26,6 +26,9 @@ object Layout:
       |.download .raw-title .progress { margin-left: 15px; color: #333 }
       |.download-status .fields .field { display:block; float: none; clear: both; position: relative; margin-bottom: 10px }
       |.download-status .fields .name { font-weight:bold }
+      |.new-download input { min-width:200px; }
+      |.new-download span { margin-right: 10px }
+      |.new-download .input-wrap { margin-bottom: 10px }
       |""".stripMargin
 
   def layout[T <: String](
@@ -91,11 +94,16 @@ object Layout:
     div(
       cls := "new-download",
       form(
-        action := "/new-download",
-        method := "post",
+        action  := "/new-download",
+        method  := "post",
+        enctype := "multipart/form-data",
         div(
           cls        := "input-wrap",
-          label("URI or Magnet", input(`type` := "text", name := "uri", value := maybeUri.getOrElse("")))
+          label(span("URI or Magnet"), input(`type` := "text", name := "uri", value := maybeUri.getOrElse("")))
+        ),
+        div(
+          cls        := "input-wrap",
+          label(span("Torrent file"), input(`type` := "file", name := "file"))
         ),
         br(),
         div(cls      := "input-wrap", input(`type` := "submit", value := "Add URI / Magnet")),


### PR DESCRIPTION
With this PR, I want to extend the ability to pass Magnet links to Aria and **upload** and encode Torrent files. 

The torrent field will then be passed to [`aria2.addTorrent` RPC method](https://aria2.github.io/manual/en/html/aria2c.html#aria2.addTorrent)

Resources:

- https://github.com/openmole/openmole/blob/0c68d603de6d21352ecfeda7a51c9ff4e8be1ca0/openmole/gui/server/org.openmole.gui.server.core/src/main/scala/org/openmole/gui/server/core/RESTAPIv1Server.scala#L56
- https://github.com/http4s/http4s/blob/0852b7ad5edc45c690c2eba67a07f1c25599ee03/examples/blaze/src/main/scala/com/example/http4s/blaze/ClientMultipartPostExample.scala
- https://aria2.github.io/manual/en/html/aria2c.html#aria2.addTorrent